### PR TITLE
Update HexDoc URL

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ import Config
 Application.start(:nerves_bootstrap)
 
 # Customize non-Elixir parts of the firmware. See
-# https://hexdocs.pm/nerves/advanced-configuration.html for details.
+# https://nerves.hexdocs.pm/advanced-configuration.html for details.
 
 config :nerves, :firmware,
   rootfs_overlay: "rootfs_overlay",

--- a/config/host.exs
+++ b/config/host.exs
@@ -10,8 +10,8 @@ config :nerves_runtime,
        # this allows us to use a pre-populated InMemory store when running on
        # host for development and testing.
        #
-       # https://hexdocs.pm/nerves_runtime/readme.html#using-nerves_runtime-in-tests
-       # https://hexdocs.pm/nerves_runtime/readme.html#nerves-system-and-firmware-metadata
+       # https://nerves-runtime.hexdocs.pm/readme.html#using-nerves_runtime-in-tests
+       # https://nerves-runtime.hexdocs.pm/readme.html#nerves-system-and-firmware-metadata
 
        "nerves_fw_active" => "a",
        "a.nerves_fw_architecture" => "generic",

--- a/config/target.exs
+++ b/config/target.exs
@@ -3,7 +3,7 @@ import Config
 config :nerves_runtime, startup_guard_enabled: true
 
 # Use Ringlogger as the logger backend and remove :console.
-# See https://hexdocs.pm/ring_logger/readme.html for more information on
+# See https://ring-logger.hexdocs.pm/readme.html for more information on
 # configuring ring_logger.
 
 config :logger, backends: [RingLogger]
@@ -23,8 +23,8 @@ config :nerves, :erlinit, update_clock: true
 
 # Configure the device for SSH IEx prompt access and firmware updates
 #
-# * See https://hexdocs.pm/nerves_ssh/readme.html for general SSH configuration
-# * See https://hexdocs.pm/ssh_subsystem_fwup/readme.html for firmware updates
+# * See https://nerves-ssh.hexdocs.pm/readme.html for general SSH configuration
+# * See https://ssh-subsystem-fwup.hexdocs.pm/readme.html for firmware updates
 
 config :nerves_ssh,
   daemon_option_overrides: [

--- a/lib/kiosk_demo/application.ex
+++ b/lib/kiosk_demo/application.ex
@@ -1,5 +1,5 @@
 defmodule KioskDemo.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -18,7 +18,7 @@ defmodule KioskDemo.Application do
         # {KioskDemo.Worker, arg},
       ] ++ phoenix_children() ++ children()
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: KioskDemo.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/kiosk_demo_web/components/core_components.ex
+++ b/lib/kiosk_demo_web/components/core_components.ex
@@ -21,7 +21,7 @@ defmodule KioskDemoWeb.CoreComponents do
 
     * [Heroicons](https://heroicons.com) - see `icon/1` for usage.
 
-    * [Phoenix.Component](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html) -
+    * [Phoenix.Component](https://phoenix-live-view.hexdocs.pm/Phoenix.Component.html) -
       the component system used by Phoenix. Some components, such as `<.link>`
       and `<.form>`, are defined there.
 

--- a/lib/kiosk_demo_web/components/layouts.ex
+++ b/lib/kiosk_demo_web/components/layouts.ex
@@ -29,7 +29,7 @@ defmodule KioskDemoWeb.Layouts do
 
   attr :current_scope, :map,
     default: nil,
-    doc: "the current [scope](https://hexdocs.pm/phoenix/scopes.html)"
+    doc: "the current [scope](https://phoenix.hexdocs.pm/scopes.html)"
 
   slot :inner_block, required: true
 

--- a/lib/kiosk_demo_web/gettext.ex
+++ b/lib/kiosk_demo_web/gettext.ex
@@ -2,7 +2,7 @@ defmodule KioskDemoWeb.Gettext do
   @moduledoc """
   A module providing Internationalization with a gettext-based API.
 
-  By using [Gettext](https://hexdocs.pm/gettext), your module compiles translations
+  By using [Gettext](https://gettext.hexdocs.pm), your module compiles translations
   that you can use in your application. To use this Gettext backend module,
   call `use Gettext` and pass it as an option:
 
@@ -19,7 +19,7 @@ defmodule KioskDemoWeb.Gettext do
       # Domain-based translation
       dgettext("errors", "Here is the error message to translate")
 
-  See the [Gettext Docs](https://hexdocs.pm/gettext) for detailed usage.
+  See the [Gettext Docs](https://gettext.hexdocs.pm) for detailed usage.
   """
   use Gettext.Backend, otp_app: :kiosk_demo
 end

--- a/lib/kiosk_demo_web/telemetry.ex
+++ b/lib/kiosk_demo_web/telemetry.ex
@@ -10,7 +10,7 @@ defmodule KioskDemoWeb.Telemetry do
   def init(_arg) do
     children = [
       # Telemetry poller will execute the given period measurements
-      # every 10_000ms. Learn more here: https://hexdocs.pm/telemetry_metrics
+      # every 10_000ms. Learn more here: https://telemetry-metrics.hexdocs.pm
       {:telemetry_poller, measurements: periodic_measurements(), period: 10_000}
       # Add reporters as children of your supervision tree.
       # {Telemetry.Metrics.ConsoleReporter, metrics: metrics()}

--- a/mix.exs
+++ b/mix.exs
@@ -104,7 +104,7 @@ defmodule KioskDemo.MixProject do
     [
       overwrite: true,
       # Erlang distribution is not started automatically.
-      # See https://hexdocs.pm/nerves_pack/readme.html#erlang-distribution
+      # See https://nerves-pack.hexdocs.pm/readme.html#erlang-distribution
       cookie: "#{@app}_cookie",
       include_erts: &Nerves.Release.erts/0,
       steps: [&Nerves.Release.init/1, :assemble],


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://phoenix-live-view.hexdocs.pm/Phoenix.Component.html): Status 404
❌ Verification failed for https://phoenix.hexdocs.pm/scopes.html): Status 404
❌ Verification failed for https://gettext.hexdocs.pm): %Req.TransportError{reason: :nxdomain}
⚠️ Verification finished: 10 success, 3 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>